### PR TITLE
Unify group chats, sender names, and via collapse

### DIFF
--- a/docs/unified-mvp.md
+++ b/docs/unified-mvp.md
@@ -10,5 +10,9 @@ This MVP stores events from local connectors (iMessage and email) in an append-o
 
 ## Usage
 ```
-python -m unified.cli.unify --person "<handle>" --jsonl
+# List chats for a person
+python -m unified.cli.unify --person "<did or handle>" --list-chats
+
+# Render a chat to markdown
+python -m unified.cli.unify --person "<did or handle>" --chat "<conversation_id>" --show-handles --out thread.md
 ```

--- a/tests/unified/test_group_view.py
+++ b/tests/unified/test_group_view.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timedelta
+from unified.eventlog import EventLog
+from unified import eventlog as eventlog_module
+from unified.hlc import HLC
+from unified.schema import EventKind, MessageEvent
+from unified.storage_sqlite import SQLiteEventStore
+from unified.views.conversation import get_conversation
+
+
+def _msg(event_id, who, chat, text, t, hlc, service="imessage", route="imessage:sms"):
+    return MessageEvent(
+        event_id=event_id,
+        kind=EventKind.MESSAGE,
+        person_did="did:person:test",
+        source={"service": service, "id": event_id, "sender": who, "route": route, "chat_guid": chat},
+        time_event=t,
+        time_observed=t,
+        hlc=hlc.now(),
+        security={"e2e": False, "bridge_mode": "NONE"},
+        provenance=[f"{service} row"],
+        tombstone=None,
+        body={"text": text, "format": "plain"},
+        rel={"conversation_id": f"{service}:chat:{chat}", "participants": [who, "me"]},
+        attachments=[],
+    )
+
+
+def test_group_and_via_collapse(tmp_path):
+    store = SQLiteEventStore(path=tmp_path / "events.db")
+    log = EventLog(store)
+    eventlog_module.default_log = log
+    hlc = HLC()
+    now = datetime.utcnow()
+
+    # Same text/time from same sender via two routes -> collapse
+    log.append_event(_msg("a1", "+1410", "CHAT1", "Hello", now, hlc, service="imessage", route="imessage:sms"))
+    log.append_event(
+        _msg("a2", "+1410", "CHAT1", "Hello", now + timedelta(seconds=30), hlc, service="imessage", route="imessage:imessage")
+    )
+
+    conv = list(
+        get_conversation(
+            "did:person:test",
+            output="objects",
+            group_by_conversation=True,
+            via_collapse=True,
+            resolve_display=lambda h, _: h,
+        )
+    )
+    # Expect a header + one message
+    assert conv[0]["kind"] == "header"
+    msg = conv[1]
+    assert msg["text"] == "Hello"
+    assert set(msg["via"]) == {"imessage:sms", "imessage:imessage"}
+    assert msg["who"] == "+1410"

--- a/tests/unified/test_merge_view.py
+++ b/tests/unified/test_merge_view.py
@@ -104,7 +104,7 @@ def test_merge_view(tmp_path):
     )
     log.append_event(delete)
 
-    conv = list(get_conversation(person))
+    conv = list(get_conversation(person, group_by_conversation=False))
     assert len(conv) == 2
     assert conv[0]["tombstone"]["reason"] == "deleted"
     assert conv[0]["reactions"] == ["👍"]
@@ -153,5 +153,5 @@ def test_stable_ordering_same_time(tmp_path):
     )
     log.append_event(second)
 
-    conv = list(get_conversation(person))
+    conv = list(get_conversation(person, group_by_conversation=False))
     assert [c["text"] for c in conv] == ["first", "second"]

--- a/tests/unified/test_sanitize.py
+++ b/tests/unified/test_sanitize.py
@@ -1,0 +1,128 @@
+from datetime import datetime
+
+from unified.sanitize import clean_urls, has_url, normalize_handle
+from unified.eventlog import EventLog
+from unified import eventlog as eventlog_module
+from unified.hlc import HLC
+from unified.schema import EventKind, MessageEvent
+from unified.storage_sqlite import SQLiteEventStore
+from unified.views.conversation import get_conversation
+from unified.cli import unify as unify_cli
+
+
+def test_clean_urls():
+    assert clean_urls("Khttps://x.y/WHttpURL/") == "https://x.y/"
+    assert clean_urls("ttps://y") == "https://y"
+
+
+def test_plugin_payload_hidden_on_url(tmp_path):
+    store = SQLiteEventStore(path=tmp_path / "events.db")
+    log = EventLog(store)
+    eventlog_module.default_log = log
+    hlc = HLC()
+    now = datetime.utcnow()
+    # message with URL and plugin attachment
+    log.append_event(
+        MessageEvent(
+            event_id="a",
+            kind=EventKind.MESSAGE,
+            person_did="did:person:test",
+            source={"service": "imessage", "id": "a", "sender": "+1"},
+            time_event=now,
+            time_observed=now,
+            hlc=hlc.now(),
+            security={"e2e": False, "bridge_mode": "NONE"},
+            provenance=["p"],
+            tombstone=None,
+            body={"text": "check https://example.com", "format": "plain"},
+            rel={"conversation_id": "chat1", "participants": ["+1"]},
+            attachments=[{"name": "link.pluginPayloadAttachment", "mime": "text/html", "uri": "p"}],
+        )
+    )
+    # message without URL but plugin attachment
+    log.append_event(
+        MessageEvent(
+            event_id="b",
+            kind=EventKind.MESSAGE,
+            person_did="did:person:test",
+            source={"service": "imessage", "id": "b", "sender": "+1"},
+            time_event=now,
+            time_observed=now,
+            hlc=hlc.now(),
+            security={"e2e": False, "bridge_mode": "NONE"},
+            provenance=["p"],
+            tombstone=None,
+            body={"text": "no url here", "format": "plain"},
+            rel={"conversation_id": "chat1", "participants": ["+1"]},
+            attachments=[{"name": "link.pluginPayloadAttachment", "mime": "text/html", "uri": "p"}],
+        )
+    )
+    conv = list(
+        get_conversation(
+            "did:person:test", output="objects", group_by_conversation=False, hide_plugin_payload=True
+        )
+    )
+    assert conv[0]["attachments"] == []
+    assert conv[1]["attachments"]
+
+
+def test_handle_normalization():
+    assert normalize_handle("+1 (410)925-6693") == "tel:+14109256693"
+    assert normalize_handle("User@Example.COM") == "mailto:user@example.com"
+
+
+def test_list_chats_cli(tmp_path, capsys):
+    store = SQLiteEventStore(path=tmp_path / "events.db")
+    log = EventLog(store)
+    eventlog_module.default_log = log
+    hlc = HLC()
+    now = datetime.utcnow()
+    for i in range(2):
+        log.append_event(
+            MessageEvent(
+                event_id=f"m{i}",
+                kind=EventKind.MESSAGE,
+                person_did="did:person:test",
+                source={"service": "imessage", "id": f"m{i}", "sender": "+1"},
+                time_event=now,
+                time_observed=now,
+                hlc=hlc.now(),
+                security={"e2e": False, "bridge_mode": "NONE"},
+                provenance=["p"],
+                tombstone=None,
+                body={"text": "x", "format": "plain"},
+                rel={"conversation_id": "room3", "participants": ["+1"]},
+                attachments=[],
+            )
+        )
+    unify_cli.main(["--person", "did:person:test", "--list-chats"])
+    out = capsys.readouterr().out.splitlines()
+    assert any("room3" in line and "2 msgs" in line for line in out)
+
+
+def test_show_handles_markdown(tmp_path, capsys):
+    store = SQLiteEventStore(path=tmp_path / "events.db")
+    log = EventLog(store)
+    eventlog_module.default_log = log
+    hlc = HLC()
+    now = datetime.utcnow()
+    log.append_event(
+        MessageEvent(
+            event_id="m1",
+            kind=EventKind.MESSAGE,
+            person_did="did:person:test",
+            source={"service": "imessage", "id": "m1", "sender": "+1410"},
+            time_event=now,
+            time_observed=now,
+            hlc=hlc.now(),
+            security={"e2e": False, "bridge_mode": "NONE"},
+            provenance=["p"],
+            tombstone=None,
+            body={"text": "hi", "format": "plain"},
+            rel={"conversation_id": "room4", "participants": ["+1410", "me"]},
+            attachments=[],
+        )
+    )
+    unify_cli.main(["--person", "did:person:test", "--chat", "room4", "--show-handles"])
+    out = capsys.readouterr().out
+    assert "tel:+1410" in out

--- a/unified/cli/unify.py
+++ b/unified/cli/unify.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import argparse
 from datetime import datetime
+from pathlib import Path
 
-from ..identity import did as did_module
-from ..views.conversation import get_conversation
+from ..identity.contacts import build_resolver
+from ..views.conversation import get_conversation, list_chats, render_markdown
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -13,26 +14,83 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--since")
     parser.add_argument("--until")
     parser.add_argument("--jsonl", action="store_true")
+    parser.add_argument("--group-by", choices=["none", "chat"], default="chat")
+    parser.add_argument("--via-collapse", action="store_true", default=False)
+    parser.add_argument("--contacts-vcf")
+    parser.add_argument("--contacts-csv")
+    parser.add_argument("--hide-plugin", action="store_true", default=True)
+    parser.add_argument("--show-plugin", dest="hide_plugin", action="store_false")
+    parser.add_argument("--list-chats", action="store_true")
+    parser.add_argument("--chat")
+    parser.add_argument("--out")
+    parser.add_argument("--show-handles", action="store_true")
     args = parser.parse_args(argv)
     person = args.person
-    if "@" in person or person.startswith("+"):
-        person_did = did_module.resolve_handles_to_person([person])
+    if person.startswith("did:"):
+        person_did = person
     else:
-        reg = did_module._load_registry()  # type: ignore[attr-defined]
-        person_did = next(
-            (d for d, info in reg.items() if info.get("label") == person), person
-        )
+        from ..identity import did as did_module  # heavy import only when needed
+        if "@" in person or person.startswith("+"):
+            person_did = did_module.resolve_handles_to_person([person])
+        else:
+            reg = did_module._load_registry()  # type: ignore[attr-defined]
+            person_did = next(
+                (d for d, info in reg.items() if info.get("label") == person), person
+            )
     since = datetime.fromisoformat(args.since) if args.since else None
     until = datetime.fromisoformat(args.until) if args.until else None
     output = "jsonl" if args.jsonl else "objects"
-    conv = get_conversation(person_did, since, until, output=output)
+    resolver = build_resolver(
+        Path(args.contacts_vcf) if args.contacts_vcf else None,
+        Path(args.contacts_csv) if args.contacts_csv else None,
+    )
+
+    if args.list_chats:
+        chats = list_chats(person_did, resolver)
+        for c in chats:
+            parts = ", ".join(c["participants"])
+            print(f"{c['conversation_id']} · {c['count']} msgs · {parts}")
+        return
+
+    if args.chat:
+        md = render_markdown(
+            person_did,
+            args.chat,
+            resolve_display=resolver,
+            show_handles=args.show_handles,
+            hide_plugin_payload=args.hide_plugin,
+            via_collapse=args.via_collapse,
+        )
+        if args.out:
+            Path(args.out).write_text(md)
+        else:
+            print(md)
+        return
+
+    conv = get_conversation(
+        person_did,
+        since,
+        until,
+        output=output,
+        group_by_conversation=(args.group_by == "chat"),
+        via_collapse=args.via_collapse,
+        resolve_display=resolver,
+        hide_plugin_payload=args.hide_plugin,
+    )
     if output == "jsonl":
         for line in conv:  # type: ignore[assignment]
             print(line)
     else:
         for item in conv:  # type: ignore[assignment]
+            if item.get("kind") == "header":
+                parts = ", ".join(item.get("participants", []))
+                cid = item.get("conversation_id") or ""
+                print(f"## Conversation {cid}\nParticipants: {parts}")
+                continue
             text = item.get("text", "")
-            print(f"{item['timestamp']} {item['who']}: {text}")
+            via = item.get("via", [])
+            via_s = f"  (via: {', '.join(via)})" if via else ""
+            print(f"{item['timestamp']} — {item['who']}: {text}{via_s}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/unified/connectors/email_imap.py
+++ b/unified/connectors/email_imap.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import email
 from email import policy
-from email.utils import parsedate_to_datetime
+from email.utils import parsedate_to_datetime, parseaddr
 from pathlib import Path
 from datetime import datetime
 
@@ -12,12 +12,28 @@ from ..schema import EventKind, MessageEvent
 from ..trust import BridgeMode
 
 
+def _thread_root_id(msg: email.message.Message) -> str:
+    """Pick a stable thread id: first of References, else In-Reply-To, else Message-ID."""
+    refs = msg.get("References")
+    if refs:
+        # References: space-separated list of <id>
+        first = refs.strip().split()[0]
+        return first.strip("<>")
+    irt = msg.get("In-Reply-To")
+    if irt:
+        return irt.strip().strip("<>")
+    mid = msg.get("Message-ID", "").strip()
+    return mid.strip("<>") or "no-id"
+
+
 def ingest_eml_dir(dir_path: Path, person_did: str, log: EventLog, hlc: HLC) -> None:
     for path in sorted(dir_path.glob("*.eml")):
         with path.open("r", encoding="utf-8", errors="ignore") as f:
             msg = email.message_from_file(f, policy=policy.default)
         body = msg.get_body(preferencelist=("plain",))
         text = body.get_content() if body else ""
+        disp_name, from_addr = parseaddr(msg.get("From", ""))
+        thread_id = _thread_root_id(msg)
         event = MessageEvent(
             event_id=msg.get("Message-ID", path.name),
             kind=EventKind.MESSAGE,
@@ -25,7 +41,9 @@ def ingest_eml_dir(dir_path: Path, person_did: str, log: EventLog, hlc: HLC) -> 
             source={
                 "service": "email",
                 "id": msg.get("Message-ID", path.name),
-                "sender": "other",
+                "sender": from_addr or "unknown",
+                "display_name": disp_name or None,
+                "route": "email",
             },
             time_event=(
                 parsedate_to_datetime(msg.get("Date"))
@@ -41,6 +59,8 @@ def ingest_eml_dir(dir_path: Path, person_did: str, log: EventLog, hlc: HLC) -> 
             rel={
                 "in_reply_to": msg.get("In-Reply-To"),
                 "message_id": msg.get("Message-ID"),
+                "conversation_id": f"email:thread:{thread_id}",
+                "participants": [],  # optional: can derive later from headers
             },
             attachments=[],
         )

--- a/unified/connectors/imessage.py
+++ b/unified/connectors/imessage.py
@@ -21,10 +21,52 @@ def ingest_chatdb(
     conn = connect_readonly(str(db_path))
     conn.row_factory = sqlite3.Row
     cur = conn.cursor()
-    for row in cur.execute(
-        "SELECT ROWID as rowid, guid, text, date, is_from_me FROM message ORDER BY date"
-    ):
+
+    # Pull sender handle and room; we may get multiple chat rows per message (multi-room edge cases)
+    q = """
+    SELECT
+      m.ROWID                  AS rowid,
+      m.guid                   AS msg_guid,
+      m.text                   AS text,
+      m.date                   AS date,
+      m.is_from_me             AS is_from_me,
+      h.id                     AS sender_handle,
+      h.service                AS sender_service,
+      c.guid                   AS chat_guid,
+      c.chat_identifier        AS chat_identifier
+    FROM message m
+    LEFT JOIN handle h           ON h.ROWID = m.handle_id
+    LEFT JOIN chat_message_join cmj ON cmj.message_id = m.ROWID
+    LEFT JOIN chat c             ON c.ROWID = cmj.chat_id
+    ORDER BY m.date, m.ROWID;
+    """
+
+    # Preload participants per chat_id to avoid N+1 lookups
+    participants_cache: dict[str, list[str]] = {}
+
+    def participants_for(chat_guid: str) -> list[str]:
+        if not chat_guid:
+            return []
+        if chat_guid in participants_cache:
+            return participants_cache[chat_guid]
+        rows = conn.execute(
+            """
+            SELECT h.id
+            FROM chat
+            JOIN chat_handle_join chj ON chj.chat_id = chat.ROWID
+            JOIN handle h             ON h.ROWID = chj.handle_id
+            WHERE chat.guid = ?
+            """,
+            (chat_guid,),
+        ).fetchall()
+        vals = sorted({r["id"] for r in rows})
+        participants_cache[chat_guid] = vals
+        return vals
+
+    for row in cur.execute(q):
         ts = apple_ts_to_dt_local(row["date"])
+        chat_guid = row["chat_guid"] or ""
+
         # attachments references
         att_rows = cur.execute(
             """
@@ -36,14 +78,19 @@ def ingest_chatdb(
             (row["rowid"],),
         ).fetchall()
         attachments = [{"name": r[0], "mime": r[1], "uri": r[2]} for r in att_rows]
+
+        # Sender: for is_from_me==0 the actual sender is handle.id; else "me"
+        sender = "me" if row["is_from_me"] else (row["sender_handle"] or "unknown")
         event = MessageEvent(
-            event_id=row["guid"],
+            event_id=row["msg_guid"],
             kind=EventKind.MESSAGE,
             person_did=person_did,
             source={
                 "service": "imessage",
-                "id": row["guid"],
-                "sender": "me" if row["is_from_me"] else "other",
+                "id": row["msg_guid"],
+                "sender": sender,
+                "chat_guid": chat_guid,
+                "route": f"imessage:{row['sender_service'] or 'unknown'}",
             },
             time_event=ts,
             time_observed=datetime.utcnow(),
@@ -52,7 +99,10 @@ def ingest_chatdb(
             provenance=[f"imessage.message {row['rowid']}"],
             tombstone=None,
             body={"text": row["text"], "format": "plain"},
-            rel={},
+            rel={
+                "conversation_id": f"imessage:chat:{chat_guid}" if chat_guid else None,
+                "participants": participants_for(chat_guid),
+            },
             attachments=attachments,
         )
         log.append_event(event)

--- a/unified/identity/contacts.py
+++ b/unified/identity/contacts.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import csv
+import json
+import os
+import platform
+import subprocess
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+PEOPLE_PATH = Path.home() / ".imx/unified/people.json"
+
+def _load_people() -> Dict[str, Dict[str, object]]:
+    if PEOPLE_PATH.exists():
+        return json.loads(PEOPLE_PATH.read_text(encoding="utf-8"))
+    return {}
+
+def load_vcf(path: Path) -> Dict[str, str]:
+    """Very small vCard parser for TEL/EMAIL → FN mapping (no third-party deps)."""
+    mapping: Dict[str, str] = {}
+    if not path.exists():
+        return mapping
+    name = None
+    for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = line.strip()
+        if line.upper().startswith("FN:"):
+            name = line.split(":", 1)[1].strip()
+        elif line.upper().startswith("TEL") or line.upper().startswith("EMAIL"):
+            if ":" in line:
+                handle = line.split(":", 1)[1].strip()
+                if handle and name:
+                    mapping[handle] = name
+    return mapping
+
+def load_csv(path: Path) -> Dict[str, str]:
+    """CSV with columns: name, handle (phone/email)."""
+    mapping: Dict[str, str] = {}
+    if not path.exists():
+        return mapping
+    with path.open(newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            handle = (row.get("handle") or "").strip()
+            name = (row.get("name") or "").strip()
+            if handle and name:
+                mapping[handle] = name
+    return mapping
+
+def query_macos_contacts(handle: str) -> Optional[str]:
+    """Best-effort Apple Contacts lookup via AppleScript (Darwin only)."""
+    if platform.system() != "Darwin":
+        return None
+    script = f'''
+    on hasValueWithSubstring(theList, theSub)
+        repeat with v in theList
+            if (v as text) contains theSub then return true
+        end repeat
+        return false
+    end hasValueWithSubstring
+    tell application "Contacts"
+        set matches to {{}}
+        repeat with p in people
+            set allVals to (value of phones of p) & (value of emails of p)
+            if my hasValueWithSubstring(allVals, "{handle}") then
+                copy name of p to end of matches
+            end if
+        end repeat
+        if (count of matches) > 0 then return item 1 of matches
+        return ""
+    end tell
+    '''
+    try:
+        out = subprocess.check_output(["osascript", "-e", script], text=True).strip()
+        return out or None
+    except Exception:
+        return None
+
+def build_resolver(contacts_vcf: Optional[Path] = None, contacts_csv: Optional[Path] = None):
+    people = _load_people()
+    by_handle: Dict[str, str] = {}
+
+    # From people.json VCs
+    for did, info in people.items():
+        label = (info.get("label") or "") if isinstance(info, dict) else ""
+        for vc_id in (info.get("vc_ids") or []):
+            # wallet.load_vc not imported to avoid circular; rely on label for now
+            pass
+        # Also allow raw handles list if present
+        for h in (info.get("handles") or []):
+            if isinstance(h, str) and label:
+                by_handle[h] = label
+
+    # External sources
+    if contacts_vcf:
+        by_handle.update(load_vcf(contacts_vcf))
+    if contacts_csv:
+        by_handle.update(load_csv(contacts_csv))
+
+    def resolve(handle: Optional[str], fallback_display: Optional[str] = None) -> str:
+        if not handle:
+            return fallback_display or "Unknown"
+        # exact
+        if handle in by_handle:
+            return by_handle[handle]
+        # heuristic: strip formatting for phone numbers
+        digits = "".join(ch for ch in handle if ch.isdigit() or ch == "+")
+        for k, v in by_handle.items():
+            kd = "".join(ch for ch in k if ch.isdigit() or ch == "+")
+            if kd and kd == digits:
+                return v
+        # macOS contacts last
+        mac = query_macos_contacts(handle)
+        if mac:
+            return mac
+        return fallback_display or handle
+
+    return resolve

--- a/unified/sanitize.py
+++ b/unified/sanitize.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import re
+
+# Remove leading stray char before http(s), fix ttps://, strip WHttpURL/ trailer.
+def clean_urls(text: str) -> str:
+    if not text:
+        return text
+    t = text.replace("WHttpURL/", "")
+    # remove stray leading char like 'K' before https://
+    t = re.sub(r'\b([A-Za-z\*])(?=https?://)', '', t)
+    # fix ttps:// or Ttps://
+    t = re.sub(r'\b[tT]tps://', 'https://', t)
+    return t
+
+
+def has_url(text: str) -> bool:
+    return bool(re.search(r'https?://\S+', text or ""))
+
+
+# Basic handle normalizer used for display
+PHONE_RE = re.compile(r'\D')
+
+
+def normalize_handle(handle: str) -> str:
+    h = (handle or "").strip()
+    if not h:
+        return ""
+    if '@' in h or h.lower().startswith('mailto:'):
+        addr = h.split(':', 1)[1] if h.lower().startswith('mailto:') else h
+        return f"mailto:{addr.lower()}"
+    # phone numbers
+    plus = '+' if h.startswith('+') else ''
+    digits = PHONE_RE.sub('', h)
+    if plus:
+        digits = '+' + digits
+    if not digits.startswith('+'):
+        if len(digits) == 10:
+            digits = '+1' + digits
+        else:
+            digits = '+' + digits
+    return f"tel:{digits}"

--- a/unified/storage_sqlite.py
+++ b/unified/storage_sqlite.py
@@ -47,6 +47,12 @@ class SQLiteEventStore:
         cur.execute(
             "CREATE INDEX IF NOT EXISTS idx_person_time ON events(person_did, time_event)"
         )
+        try:
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_conv_time ON events(json_extract(body_json, '$.rel.conversation_id'), time_event)"
+            )
+        except sqlite3.OperationalError:
+            pass
         self.conn.commit()
 
     def append(self, event: BaseEvent) -> None:

--- a/unified/views/conversation.py
+++ b/unified/views/conversation.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import hashlib
 import json
-from datetime import datetime
-from typing import List, Tuple
+from datetime import datetime, timedelta
+from typing import Callable, Dict, List, Tuple
 
 from ..eventlog import iter_events
 from ..schema import BaseEvent, EventKind
 from ..trust import TrustBadge
 from ..hlc import HLC
+from ..sanitize import clean_urls, has_url, normalize_handle
 
 
 def _badge_for(event: BaseEvent) -> str:
@@ -25,6 +27,11 @@ def get_conversation(
     until: datetime | None = None,
     include: Tuple[str, ...] = ("messages", "calls", "attachments", "reactions"),
     output: str = "objects",
+    *,
+    group_by_conversation: bool = True,
+    via_collapse: bool = False,
+    resolve_display: Callable[[str | None, str | None], str] | None = None,
+    hide_plugin_payload: bool = True,
 ):
     events = list(iter_events(person_did, since, until))
     events.sort(
@@ -36,22 +43,69 @@ def get_conversation(
     )
     items: List[dict] = []
     index: dict[str, dict] = {}
+    # Helper for dedupe
+    def normalize_text(s: str) -> str:
+        return (s or "").strip()
+
+    def fp_key(text: str, when_iso: str, who: str | None) -> str:
+        # Round to nearest 120s to tolerate slight skews
+        try:
+            dt = datetime.fromisoformat(when_iso)
+        except Exception:
+            dt = datetime.fromisoformat(when_iso.replace("Z", "+00:00"))
+        epoch = int(dt.timestamp())
+        rounded = datetime.fromtimestamp((epoch // 120) * 120, tz=dt.tzinfo)
+        base = f"{normalize_text(text)}|{rounded.isoformat()}|{who or ''}"
+        return hashlib.sha256(base.encode("utf-8")).hexdigest()
+
+    seen: Dict[str, dict] = {}
     for ev in events:
         if ev.kind == EventKind.MESSAGE:
             me = ev  # type: MessageEvent
-            item = {
+            conversation_id = (me.rel or {}).get("conversation_id")
+            who_raw = me.source.get("sender")
+            display_who = (
+                resolve_display(who_raw, me.source.get("display_name"))
+                if resolve_display
+                else (who_raw or "other")
+            )
+            raw_text = me.body.get("text", "")
+            text = clean_urls(raw_text)
+            atts = me.attachments if "attachments" in include else []
+            if hide_plugin_payload and has_url(text):
+                atts = [a for a in atts if not str(a.get("name", "")).endswith(".pluginPayloadAttachment")]
+            base_item = {
                 "timestamp": me.time_event.isoformat(),
-                "who": me.source.get("sender", "other"),
+                "who": display_who,
+                "who_handle": who_raw,
                 "kind": "message",
-                "text": me.body.get("text", ""),
-                "attachments": me.attachments if "attachments" in include else [],
+                "text": text,
+                "attachments": atts,
                 "rel": me.rel,
+                "conversation_id": conversation_id,
                 "trust_badge": _badge_for(me),
                 "provenance": me.provenance,
+                "via": [me.source.get("route") or me.source.get("service")],
                 "reactions": [],
             }
-            items.append(item)
-            index[me.event_id] = item
+            if via_collapse:
+                k = fp_key(base_item["text"], base_item["timestamp"], who_raw)
+                existing = seen.get(k)
+                if existing:
+                    for v in base_item["via"]:
+                        if v and v not in existing["via"]:
+                            existing["via"].append(v)
+                    existing["provenance"].extend(
+                        x for x in base_item["provenance"] if x not in existing["provenance"]
+                    )
+                    index[me.event_id] = existing
+                else:
+                    seen[k] = base_item
+                    items.append(base_item)
+                    index[me.event_id] = base_item
+            else:
+                items.append(base_item)
+                index[me.event_id] = base_item
         elif ev.kind == EventKind.EDIT:
             ee = ev  # type: EditEvent
             target = index.get(ee.target_event_id)
@@ -82,6 +136,100 @@ def get_conversation(
                 "provenance": ce.provenance,
             }
             items.append(item)
+
+    # Optionally group by conversation with headers (objects mode can still include)
+    if group_by_conversation and output != "jsonl":
+        grouped: Dict[str | None, List[dict]] = {}
+        meta: Dict[str | None, dict] = {}
+        for it in items:
+            cid = it.get("conversation_id")
+            grouped.setdefault(cid, []).append(it)
+            rel = it.get("rel") or {}
+            participants = rel.get("participants") or []
+            names = []
+            for h in participants:
+                if resolve_display:
+                    names.append(resolve_display(h, None))
+                else:
+                    names.append(h)
+            meta.setdefault(cid, {"participants": sorted(set(names))})
+        flattened: List[dict] = []
+        for cid, rows in grouped.items():
+            header = {
+                "kind": "header",
+                "conversation_id": cid,
+                "participants": meta.get(cid, {}).get("participants", []),
+            }
+            flattened.append(header)
+            flattened.extend(rows)
+        items = flattened
+
     if output == "jsonl":
         return (json.dumps(it, sort_keys=True) for it in items)
     return items
+
+
+def list_chats(person_did: str, resolve_display: Callable[[str | None, str | None], str] | None = None) -> List[dict]:
+    chats: Dict[str, dict] = {}
+    for ev in iter_events(person_did):
+        if ev.kind != EventKind.MESSAGE:
+            continue
+        rel = getattr(ev, "rel", {}) or {}
+        cid = rel.get("conversation_id")
+        if not cid:
+            continue
+        meta = chats.setdefault(cid, {"participants": set(), "count": 0})
+        meta["count"] += 1
+        for h in rel.get("participants") or []:
+            name = resolve_display(h, None) if resolve_display else h
+            meta["participants"].add(name)
+    out: List[dict] = []
+    for cid, meta in chats.items():
+        out.append(
+            {
+                "conversation_id": cid,
+                "participants": sorted(meta["participants"]),
+                "count": meta["count"],
+            }
+        )
+    return sorted(out, key=lambda d: d["conversation_id"])  # deterministic order
+
+
+def render_markdown(
+    person_did: str,
+    conversation_id: str,
+    resolve_display: Callable[[str | None, str | None], str] | None = None,
+    show_handles: bool = False,
+    hide_plugin_payload: bool = True,
+    via_collapse: bool = False,
+) -> str:
+    items = list(
+        get_conversation(
+            person_did,
+            output="objects",
+            group_by_conversation=True,
+            via_collapse=via_collapse,
+            resolve_display=resolve_display,
+            hide_plugin_payload=hide_plugin_payload,
+        )
+    )
+    lines: List[str] = []
+    participants: List[str] = []
+    collecting = False
+    for it in items:
+        if it.get("kind") == "header":
+            collecting = it.get("conversation_id") == conversation_id
+            if collecting:
+                participants = it.get("participants", [])
+                lines.append(f"# Thread: {conversation_id}")
+                lines.append("Participants: " + ", ".join(participants))
+                lines.append("")
+            continue
+        if not collecting:
+            continue
+        who = it.get("who")
+        handle = it.get("who_handle")
+        if show_handles and handle not in (None, "me"):
+            who = f"{who} ({normalize_handle(handle)})"
+        lines.append(f"{it['timestamp']} — {who}: {it.get('text', '')}")
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Sanitize URLs and normalize handles for cleaner message rendering
- Filter plugin preview attachments only when messages contain URLs
- Add chat-listing and markdown export CLI with optional handle display; via collapse now opt-in

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b63580d8ac8330a49babb4ac71813d