### PR TITLE
Add voice manuscript view with handle normalization and CLI

### DIFF
--- a/docs/unified-mvp.md
+++ b/docs/unified-mvp.md
@@ -16,3 +16,16 @@ python -m unified.cli.unify --person "<did or handle>" --list-chats
 # Render a chat to markdown
 python -m unified.cli.unify --person "<did or handle>" --chat "<conversation_id>" --show-handles --out thread.md
 ```
+
+### Voice view
+
+Extract a person's authored lines across rooms with surrounding context:
+
+```
+python -m unified.cli.unify --voice-of lindseyagriffith@gmail.com --context 2 --out voice-lindsey.md
+python -m unified.cli.unify --voice-of +13169921361 --quotes-only
+```
+
+`--context` controls how many neighboring messages to include on either side of
+each authored line. `--quotes-only` lists only the target's messages while
+keeping room headers for orientation.

--- a/tests/unified/test_voice.py
+++ b/tests/unified/test_voice.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from unified.eventlog import EventLog
+from unified import eventlog as eventlog_module
+from unified.hlc import HLC
+from unified.schema import EventKind, MessageEvent
+from unified.storage_sqlite import SQLiteEventStore
+from unified.views.voice import render_voice_manuscript
+from unified.identity import contacts
+from unified.identity.contacts import normalize_handle_for_matching
+
+
+def _msg(event_id, who, cid, text, t, hlc, service="imessage", route="imessage:sms", attachments=None, participants=None):
+    return MessageEvent(
+        event_id=event_id,
+        kind=EventKind.MESSAGE,
+        person_did="did:person:test",
+        source={"service": service, "id": event_id, "sender": who, "route": route},
+        time_event=t,
+        time_observed=t,
+        hlc=hlc.now(),
+        security={"e2e": False, "bridge_mode": "NONE"},
+        provenance=[f"{service} row"],
+        tombstone=None,
+        body={"text": text, "format": "plain"},
+        rel={"conversation_id": cid, "participants": participants or [who, "me"]},
+        attachments=attachments or [],
+    )
+
+
+def _setup(tmp_path: Path) -> tuple[EventLog, HLC]:
+    store = SQLiteEventStore(path=tmp_path / "events.db")
+    log = EventLog(store)
+    eventlog_module.default_log = log
+    return log, HLC()
+
+
+def _people(tmp_path: Path, data: dict) -> None:
+    p = tmp_path / "people.json"
+    p.write_text(json.dumps(data))
+    contacts.PEOPLE_PATH = p
+    contacts.DEFAULT_VCF = None
+    contacts.DEFAULT_CSV = None
+
+
+def test_voice_same_from_email_and_phone(tmp_path):
+    _people(
+        tmp_path,
+        {
+            "Lindsey": {
+                "label": "Lindsey Griffith",
+                "handles": [
+                    "mailto:lindseyagriffith@gmail.com",
+                    "tel:+13169921361",
+                ],
+            }
+        },
+    )
+    log, hlc = _setup(tmp_path)
+    t = datetime(2021, 1, 1, 12, 0, 0)
+    log.append_event(_msg("m1", "+13169921361", "imessage:chat:1", "hi", t, hlc))
+    log.append_event(
+        _msg(
+            "m2",
+            "lindseyagriffith@gmail.com",
+            "email:thread:2",
+            "hi",
+            t + timedelta(minutes=1),
+            hlc,
+            service="email",
+            route="email",
+        )
+    )
+    md_phone = render_voice_manuscript(
+        "did:person:test",
+        "+13169921361",
+        context=0,
+        resolve_display=lambda h, _: h,
+    )
+    md_email = render_voice_manuscript(
+        "did:person:test",
+        "lindseyagriffith@gmail.com",
+        context=0,
+        resolve_display=lambda h, _: h,
+    )
+    assert md_phone == md_email
+
+
+def test_voice_context_window_merge(tmp_path):
+    _people(tmp_path, {"P": {"label": "P", "handles": ["tel:+1000"]}})
+    log, hlc = _setup(tmp_path)
+    t = datetime(2021, 1, 1, 12, 0, 0)
+    cid = "imessage:chat:room"
+    log.append_event(_msg("a", "Bob", cid, "0", t, hlc))
+    log.append_event(_msg("b", "+1000", cid, "1", t + timedelta(seconds=1), hlc))
+    log.append_event(_msg("c", "Bob", cid, "2", t + timedelta(seconds=2), hlc))
+    log.append_event(_msg("d", "+1000", cid, "3", t + timedelta(seconds=3), hlc))
+    log.append_event(_msg("e", "Bob", cid, "4", t + timedelta(seconds=4), hlc))
+    md = render_voice_manuscript(
+        "did:person:test",
+        "+1000",
+        context=1,
+        resolve_display=lambda h, _: h,
+    )
+    lines = [ln for ln in md.splitlines() if "—" in ln]
+    assert len(lines) == 5
+
+
+def test_quotes_only(tmp_path):
+    _people(tmp_path, {"P": {"label": "P", "handles": ["tel:+1000"]}})
+    log, hlc = _setup(tmp_path)
+    t = datetime(2021, 1, 1, 12, 0, 0)
+    cid = "imessage:chat:room"
+    log.append_event(_msg("a", "Bob", cid, "0", t, hlc))
+    log.append_event(_msg("b", "+1000", cid, "1", t + timedelta(seconds=1), hlc))
+    log.append_event(_msg("c", "Bob", cid, "2", t + timedelta(seconds=2), hlc))
+    md = render_voice_manuscript(
+        "did:person:test",
+        "+1000",
+        quotes_only=True,
+        resolve_display=lambda h, _: h,
+    )
+    lines = [ln for ln in md.splitlines() if "—" in ln]
+    # Only one utterance from target
+    assert len(lines) == 1
+
+
+def test_handle_normalization_controls():
+    dirty = "+‪13169921361‬"
+    clean = "+13169921361"
+    assert normalize_handle_for_matching(dirty) == normalize_handle_for_matching(clean)
+
+
+def test_plugin_preview_filter_in_voice(tmp_path):
+    _people(tmp_path, {"P": {"label": "P", "handles": ["tel:+1000"]}})
+    log, hlc = _setup(tmp_path)
+    t = datetime(2021, 1, 1, 12, 0, 0)
+    cid = "imessage:chat:room"
+    log.append_event(
+        _msg(
+            "a",
+            "+1000",
+            cid,
+            "see https://example.com",
+            t,
+            hlc,
+            attachments=[{"name": "preview.pluginPayloadAttachment"}],
+        )
+    )
+    log.append_event(
+        _msg(
+            "b",
+            "+1000",
+            cid,
+            "no link",
+            t + timedelta(seconds=1),
+            hlc,
+            attachments=[{"name": "keep.pluginPayloadAttachment"}],
+        )
+    )
+    md = render_voice_manuscript(
+        "did:person:test",
+        "+1000",
+        context=0,
+        resolve_display=lambda h, _: h,
+    )
+    lines = [ln for ln in md.splitlines() if "—" in ln]
+    assert "attachment: preview.pluginPayloadAttachment" not in lines[0]
+    assert "attachment: keep.pluginPayloadAttachment" in lines[1]
+
+
+def test_via_collapse_opt_in(tmp_path):
+    _people(tmp_path, {"P": {"label": "P", "handles": ["tel:+1000"]}})
+    log, hlc = _setup(tmp_path)
+    t = datetime(2021, 1, 1, 12, 0, 0)
+    cid = "imessage:chat:room"
+    log.append_event(_msg("a", "+1000", cid, "hi", t, hlc, route="sms"))
+    log.append_event(_msg("b", "+1000", cid, "hi", t + timedelta(seconds=30), hlc, route="imessage"))
+    md_no = render_voice_manuscript(
+        "did:person:test",
+        "+1000",
+        context=0,
+        resolve_display=lambda h, _: h,
+    )
+    md_yes = render_voice_manuscript(
+        "did:person:test",
+        "+1000",
+        context=0,
+        via_collapse=True,
+        resolve_display=lambda h, _: h,
+    )
+    lines_no = [ln for ln in md_no.splitlines() if "—" in ln]
+    lines_yes = [ln for ln in md_yes.splitlines() if "—" in ln]
+    assert len(lines_no) == 2
+    assert len(lines_yes) == 1
+
+
+def test_stable_ordering(tmp_path):
+    _people(tmp_path, {"P": {"label": "P", "handles": ["tel:+1000"]}})
+    log, hlc = _setup(tmp_path)
+    t = datetime(2021, 1, 1, 12, 0, 0)
+    cid = "imessage:chat:room"
+    # Generate two HLC values
+    hlc1 = hlc.now()
+    hlc2 = hlc.now()
+    msg1 = MessageEvent(
+        event_id="a",
+        kind=EventKind.MESSAGE,
+        person_did="did:person:test",
+        source={"service": "imessage", "id": "a", "sender": "+1000", "route": "sms"},
+        time_event=t,
+        time_observed=t,
+        hlc=hlc1,
+        security={"e2e": False, "bridge_mode": "NONE"},
+        provenance=["imessage row"],
+        tombstone=None,
+        body={"text": "first", "format": "plain"},
+        rel={"conversation_id": cid, "participants": ["+1000", "me"]},
+        attachments=[],
+    )
+    msg2 = MessageEvent(
+        event_id="b",
+        kind=EventKind.MESSAGE,
+        person_did="did:person:test",
+        source={"service": "imessage", "id": "b", "sender": "+1000", "route": "sms"},
+        time_event=t,
+        time_observed=t,
+        hlc=hlc2,
+        security={"e2e": False, "bridge_mode": "NONE"},
+        provenance=["imessage row"],
+        tombstone=None,
+        body={"text": "second", "format": "plain"},
+        rel={"conversation_id": cid, "participants": ["+1000", "me"]},
+        attachments=[],
+    )
+    # Append out of order
+    log.append_event(msg2)
+    log.append_event(msg1)
+    md = render_voice_manuscript(
+        "did:person:test",
+        "+1000",
+        context=0,
+        resolve_display=lambda h, _: h,
+    )
+    lines = [ln for ln in md.splitlines() if "—" in ln]
+    assert "first" in lines[0]
+    assert "second" in lines[1]
+

--- a/unified/cli/unify.py
+++ b/unified/cli/unify.py
@@ -4,13 +4,15 @@ import argparse
 from datetime import datetime
 from pathlib import Path
 
-from ..identity.contacts import build_resolver
+from ..identity import contacts
+from ..identity.contacts import build_resolver, expand_handles
 from ..views.conversation import get_conversation, list_chats, render_markdown
+from ..views.voice import render_voice_manuscript
 
 
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="imx unify")
-    parser.add_argument("--person", required=True)
+    parser.add_argument("--person")
     parser.add_argument("--since")
     parser.add_argument("--until")
     parser.add_argument("--jsonl", action="store_true")
@@ -24,26 +26,61 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--chat")
     parser.add_argument("--out")
     parser.add_argument("--show-handles", action="store_true")
+    parser.add_argument("--voice-of")
+    parser.add_argument("--context", type=int, default=2)
+    parser.add_argument("--quotes-only", action="store_true", default=False)
     args = parser.parse_args(argv)
-    person = args.person
-    if person.startswith("did:"):
-        person_did = person
-    else:
-        from ..identity import did as did_module  # heavy import only when needed
-        if "@" in person or person.startswith("+"):
-            person_did = did_module.resolve_handles_to_person([person])
-        else:
+    def resolve_person() -> str:
+        if args.person:
+            person = args.person
+            if person.startswith("did:"):
+                return person
+            from ..identity import did as did_module  # heavy import only when needed
+            if "@" in person or person.startswith("+"):
+                return did_module.resolve_handles_to_person([person])
             reg = did_module._load_registry()  # type: ignore[attr-defined]
-            person_did = next(
-                (d for d, info in reg.items() if info.get("label") == person), person
-            )
+            return next((d for d, info in reg.items() if info.get("label") == person), person)
+        from ..storage_sqlite import SQLiteEventStore
+        store = SQLiteEventStore()
+        cur = store.conn.cursor()
+        cur.execute("SELECT DISTINCT person_did FROM events")
+        rows = [r[0] for r in cur.fetchall()]
+        if len(rows) == 1:
+            return rows[0]
+        raise SystemExit("--person required (multiple persons found)")
+
+    person_did = resolve_person()
     since = datetime.fromisoformat(args.since) if args.since else None
     until = datetime.fromisoformat(args.until) if args.until else None
     output = "jsonl" if args.jsonl else "objects"
-    resolver = build_resolver(
-        Path(args.contacts_vcf) if args.contacts_vcf else None,
-        Path(args.contacts_csv) if args.contacts_csv else None,
-    )
+    contacts.DEFAULT_VCF = Path(args.contacts_vcf) if args.contacts_vcf else None
+    contacts.DEFAULT_CSV = Path(args.contacts_csv) if args.contacts_csv else None
+    resolver = build_resolver(contacts.DEFAULT_VCF, contacts.DEFAULT_CSV)
+
+    if args.voice_of:
+        display, handles, explain = expand_handles(
+            args.voice_of, contacts.DEFAULT_VCF, contacts.DEFAULT_CSV
+        )
+        print(
+            f'Resolved "{display}" → {{{", ".join(sorted(handles))}}} ({len(handles)} handles)'
+        )
+        md = render_voice_manuscript(
+            person_did,
+            args.voice_of,
+            since=since,
+            until=until,
+            context=args.context,
+            quotes_only=args.quotes_only,
+            show_handles=args.show_handles,
+            via_collapse=args.via_collapse,
+            hide_plugin_payload=args.hide_plugin,
+            resolve_display=resolver,
+        )
+        if args.out:
+            Path(args.out).write_text(md)
+        else:
+            print(md)
+        return
 
     if args.list_chats:
         chats = list_chats(person_did, resolver)

--- a/unified/views/voice.py
+++ b/unified/views/voice.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from collections import defaultdict
+import hashlib
+from datetime import datetime
+from typing import Callable, Dict, List, Set, Tuple
+
+from ..eventlog import iter_events
+from ..hlc import HLC
+from ..identity.contacts import expand_handles, normalize_handle_for_matching
+from ..sanitize import clean_urls, has_url
+from ..schema import EventKind, MessageEvent
+
+
+def _fp_key(text: str, when: datetime, who: str | None) -> str:
+    epoch = int(when.timestamp())
+    rounded = datetime.fromtimestamp((epoch // 120) * 120, tz=when.tzinfo)
+    base = f"{text.strip()}|{rounded.isoformat()}|{who or ''}"
+    return hashlib.sha256(base.encode("utf-8")).hexdigest()
+
+
+def _merge_ranges(ranges: List[Tuple[int, int]]) -> Set[int]:
+    if not ranges:
+        return set()
+    ranges.sort()
+    merged: List[Tuple[int, int]] = []
+    for start, end in ranges:
+        if not merged or start > merged[-1][1] + 1:
+            merged.append([start, end])  # type: ignore[list-item]
+        else:
+            merged[-1][1] = max(merged[-1][1], end)  # type: ignore[index]
+    keep: Set[int] = set()
+    for s, e in merged:
+        keep.update(range(s, e + 1))
+    return keep
+
+
+def render_voice_manuscript(
+    person_did: str,
+    seed: str,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    *,
+    context: int = 2,
+    quotes_only: bool = False,
+    show_handles: bool = False,
+    via_collapse: bool = False,
+    hide_plugin_payload: bool = True,
+    resolve_display: Callable[[str | None, str | None], str] | None = None,
+) -> str:
+    display_name, handles, _ = expand_handles(seed)
+
+    buckets: Dict[str | None, List[MessageEvent]] = defaultdict(list)
+    for ev in iter_events(person_did, since, until):
+        if ev.kind != EventKind.MESSAGE:
+            continue
+        me = ev  # type: MessageEvent
+        cid = (me.rel or {}).get("conversation_id")
+        buckets[cid].append(me)
+
+    room_blocks: List[Tuple[datetime, str | None, List[str]]] = []
+    all_lines: List[str] = []
+    overall_start: datetime | None = None
+    overall_end: datetime | None = None
+
+    for cid, events in buckets.items():
+        events.sort(
+            key=lambda e: (
+                *HLC._parse(e.hlc)[:2],
+                e.time_event.isoformat(),
+                e.event_id,
+            )
+        )
+        authored_idx = [
+            i
+            for i, e in enumerate(events)
+            if normalize_handle_for_matching(e.source.get("sender")) in handles
+        ]
+        if not authored_idx:
+            continue
+        if quotes_only:
+            keep_idx = set(authored_idx)
+        else:
+            ranges = []
+            for i in authored_idx:
+                s = max(0, i - context)
+                e = min(len(events) - 1, i + context)
+                ranges.append((s, e))
+            keep_idx = _merge_ranges(ranges)
+
+        seen: Dict[str, Tuple[int, MessageEvent, List[str]]] = {}
+        kept: List[Tuple[int, MessageEvent]] = []
+        for i, ev in enumerate(events):
+            if i not in keep_idx:
+                continue
+            if via_collapse:
+                who_norm = normalize_handle_for_matching(ev.source.get("sender"))
+                key = _fp_key(clean_urls(ev.body.get("text", "")), ev.time_event, who_norm)
+                route = ev.source.get("route") or ev.source.get("service")
+                existing = seen.get(key)
+                if existing:
+                    if route and route not in existing[2]:
+                        existing[2].append(route)
+                    continue
+                else:
+                    seen[key] = (i, ev, [r for r in [route] if r])
+            kept.append((i, ev))
+        if via_collapse:
+            kept = [seen[k][:2] for k in seen]
+            via_map = {id(ev): seen[k][2] for k, (_, ev, _) in seen.items()}
+        else:
+            via_map = {}
+
+        participant_handles: Set[str] = set()
+        for ev in events:
+            for h in (ev.rel or {}).get("participants") or []:
+                participant_handles.add(h)
+        participants: List[str] = []
+        for h in sorted(participant_handles):
+            participants.append(resolve_display(h, None) if resolve_display else h)
+
+        header = []
+        convo_name = (events[0].source.get("chat_name") or (events[0].rel or {}).get("conversation_name") or cid)
+        header.append(f"## Room: {convo_name}")
+        header.append("Participants: " + ", ".join(participants))
+        header.append("")
+        body_lines: List[str] = []
+        for i, ev in sorted(kept, key=lambda t: t[0]):
+            sender = ev.source.get("sender")
+            who = (
+                resolve_display(sender, ev.source.get("display_name"))
+                if resolve_display
+                else (sender or "Unknown")
+            )
+            norm = normalize_handle_for_matching(sender) if sender else ""
+            if show_handles and sender not in (None, "me"):
+                who = f"{who} ({norm})"
+            text = clean_urls(ev.body.get("text", ""))
+            attachments = ev.attachments
+            if hide_plugin_payload and has_url(text):
+                attachments = [a for a in attachments if not str(a.get("name", "")).endswith(".pluginPayloadAttachment")]
+            att_txt = "".join(f" [attachment: {a.get('name')}]" for a in attachments)
+            who_fmt = f"**{who}**" if i in authored_idx else who
+            ts = ev.time_event.strftime("%Y-%m-%d %H:%M")
+            via = ""
+            if via_collapse:
+                vias = via_map.get(id(ev), [])
+                if vias:
+                    via = f" (via {', '.join(sorted(set(vias)))})"
+            body_lines.append(f"{ts} — {who_fmt}: {text}{att_txt}{via}")
+            if overall_start is None or ev.time_event < overall_start:
+                overall_start = ev.time_event
+            if overall_end is None or ev.time_event > overall_end:
+                overall_end = ev.time_event
+        body_lines.append("")
+        block = header + body_lines
+        first_time = events[kept[0][0]].time_event if kept else events[0].time_event
+        room_blocks.append((first_time, cid, block))
+
+    room_blocks.sort(key=lambda t: t[0])
+    for _, _, blk in room_blocks:
+        all_lines.extend(blk)
+
+    handles_str = ", ".join(sorted(handles))
+    if overall_start and overall_end:
+        range_s = overall_start.date().isoformat()
+        range_e = overall_end.date().isoformat()
+    else:
+        range_s = range_e = "unknown"
+    top = [f"# Voice: {display_name}", f"Handles: {handles_str}   Range: {range_s} → {range_e}", ""]
+    return "\n".join(top + all_lines)
+


### PR DESCRIPTION
## Summary
- add normalization helpers and handle expansion for resolving phones/emails deterministically
- implement voice manuscript view with context windows, optional quote-only and via collapse
- extend CLI with `--voice-of` and related flags, document voice view, and add tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77c83fff88330a375f32328e985b0