### PR TITLE
Add person listing and auto-selection to unify CLI

### DIFF
--- a/docs/unified-mvp.md
+++ b/docs/unified-mvp.md
@@ -29,3 +29,17 @@ python -m unified.cli.unify --voice-of +13169921361 --quotes-only
 `--context` controls how many neighboring messages to include on either side of
 each authored line. `--quotes-only` lists only the target's messages while
 keeping room headers for orientation.
+
+### Choosing a person
+
+If your event log contains multiple local identities (multiple `person_did`s):
+
+```bash
+# List all persons with counts, date range, and services
+imx unify --list-persons
+
+# Let the CLI pick the person automatically when --voice-of uniquely identifies one
+imx unify --auto-person --voice-of someone@example.com --context 2
+```
+
+If ambiguous, the CLI prints a summary and asks you to pass `--person`.

--- a/tests/unified/test_person_resolver.py
+++ b/tests/unified/test_person_resolver.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from unified.eventlog import EventLog
+from unified import eventlog as eventlog_module
+from unified.schema import EventKind, MessageEvent
+from unified.storage_sqlite import SQLiteEventStore
+from unified.cli import person_resolver
+from unified.cli.person_resolver import db_persons, summarize_persons, guess_person_from_voice
+from unified.identity import contacts
+
+
+def _msg(event_id, did, who, svc="imessage", cid="room", text="hi", t=None):
+    t = t or datetime(2021, 1, 1, 12, 0, 0)
+    return MessageEvent(
+        event_id=event_id,
+        kind=EventKind.MESSAGE,
+        person_did=did,
+        source={"service": svc, "id": event_id, "sender": who, "route": svc},
+        time_event=t,
+        time_observed=t,
+        hlc="0:0:0",
+        security={"e2e": False, "bridge_mode": "NONE"},
+        provenance=[svc],
+        tombstone=None,
+        body={"text": text, "format": "plain"},
+        rel={"conversation_id": cid, "participants": [who, "me"]},
+        attachments=[],
+    )
+
+
+def test_guess_unique(tmp_path, monkeypatch):
+    # set people.json so expand_handles knows email <-> phone if needed
+    people = tmp_path / "people.json"
+    people.write_text(
+        '{"L":{"label":"L","handles":["mailto:l@example.com","tel:+155501"]}}'
+    )
+    monkeypatch.setattr(contacts, "PEOPLE_PATH", people)
+
+    store = SQLiteEventStore(path=tmp_path / "events.db")
+    log = EventLog(store)
+    eventlog_module.default_log = log
+    monkeypatch.setattr(person_resolver, "SQLiteEventStore", lambda: store)
+    log.append_event(_msg("a", "did:one", "l@example.com", svc="email"))
+    log.append_event(_msg("b", "did:two", "other@example.com", svc="email"))
+
+    monkeypatch.setenv("IMX_IGNORE", "1")  # noop, present to show pattern
+
+    did, evidence = guess_person_from_voice("l@example.com")
+    assert did == "did:one"
+    assert evidence["did:one"] >= 1
+
+
+def test_summarize(tmp_path, monkeypatch):
+    store = SQLiteEventStore(path=tmp_path / "events.db")
+    log = EventLog(store)
+    eventlog_module.default_log = log
+    monkeypatch.setattr(person_resolver, "SQLiteEventStore", lambda: store)
+    log.append_event(_msg("a", "did:one", "me"))
+    log.append_event(_msg("b", "did:one", "me"))
+    log.append_event(_msg("c", "did:two", "me"))
+    rows = summarize_persons()
+    assert rows[0]["person_did"] in {"did:one", "did:two"}

--- a/unified/cli/person_resolver.py
+++ b/unified/cli/person_resolver.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+from collections import defaultdict
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from ..storage_sqlite import SQLiteEventStore
+from ..eventlog import iter_events
+from ..identity import contacts
+from ..identity.contacts import expand_handles, normalize_handle_for_matching
+
+
+def db_persons() -> List[str]:
+    store = SQLiteEventStore()
+    cur = store.conn.cursor()
+    try:
+        cur.execute("SELECT DISTINCT person_did FROM events")
+        return [r[0] for r in cur.fetchall() if r and r[0]]
+    except Exception:
+        return []
+
+
+def summarize_persons() -> List[Dict[str, object]]:
+    store = SQLiteEventStore()
+    cur = store.conn.cursor()
+    counts: Dict[str, int] = {}
+    spans: Dict[str, Tuple[str, str]] = {}
+    services: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+
+    try:
+        cur.execute("SELECT person_did, COUNT(*) FROM events GROUP BY 1")
+        counts = {did: int(n) for did, n in cur.fetchall()}
+    except Exception:
+        pass
+
+    try:
+        cur.execute(
+            "SELECT person_did, MIN(time_event), MAX(time_event) FROM events GROUP BY 1"
+        )
+        spans = {did: (str(s or "?"), str(e or "?")) for did, s, e in cur.fetchall()}
+    except Exception:
+        pass
+
+    try:
+        cur.execute(
+            "SELECT person_did, json_extract(source,'$.service'), COUNT(*) FROM events GROUP BY 1,2"
+        )
+        for did, svc, c in cur.fetchall():
+            if did:
+                services[str(did)][str(svc or "?")] += int(c or 0)
+    except Exception:
+        pass
+
+    labels = {}
+    try:
+        from ..identity import did as did_module  # lazy
+
+        reg = did_module._load_registry()  # type: ignore[attr-defined]
+        labels = {d: (info.get("label") or "") for d, info in (reg or {}).items()}
+    except Exception:
+        pass
+
+    rows: List[Dict[str, object]] = []
+    for did, n in sorted(counts.items(), key=lambda kv: kv[1], reverse=True):
+        start, end = spans.get(did, ("?", "?"))
+        svcs = services.get(did, {})
+        total = sum(svcs.values()) or 1
+        top = sorted(svcs.items(), key=lambda kv: kv[1], reverse=True)[:3]
+        top_s = (
+            ", ".join(f"{name}({int(c*100/total)}%)" for name, c in top) if top else ""
+        )
+        rows.append(
+            {
+                "person_did": did,
+                "label": labels.get(did, ""),
+                "events": n,
+                "start": start,
+                "end": end,
+                "services": top_s,
+            }
+        )
+    return rows
+
+
+def print_persons_summary() -> None:
+    rows = summarize_persons()
+    if not rows:
+        print("No persons found in the event log.")
+        return
+    print("Persons discovered in the event log:")
+    for r in rows:
+        label = f' [{r["label"]}]' if r.get("label") else ""
+        print(
+            f"- {r['person_did']}{label} · {r['events']} events · {r['start']} → {r['end']} · services: {r['services']}"
+        )
+    print("\nRe-run with:  imx unify --person '<person_did>'  …")
+
+
+def _handle_variants(norm_handles: Sequence[str]) -> List[str]:
+    v: set[str] = set()
+    for h in norm_handles:
+        if h.startswith("mailto:"):
+            addr = h.split(":", 1)[1]
+            v.update({addr, addr.lower(), h, h.lower()})
+        elif h.startswith("tel:"):
+            num = h.split(":", 1)[1]
+            digits = "".join(ch for ch in num if ch.isdigit())
+            v.update({h, num, "+" + digits, digits})
+        else:
+            v.update({h, h.lower()})
+    return sorted(v)
+
+
+def guess_person_from_voice(seed: str) -> Tuple[Optional[str], Dict[str, int]]:
+    display, handles, _ = expand_handles(seed, contacts.DEFAULT_VCF, contacts.DEFAULT_CSV)
+    norm = sorted(handles)
+    variants = _handle_variants(norm)
+    evidence: Dict[str, int] = defaultdict(int)
+    store = SQLiteEventStore()
+    cur = store.conn.cursor()
+
+    if variants:
+        placeholders = ",".join(["?"] * len(variants))
+        lower_variants = [v.lower() for v in variants]
+        # Prefer SQL with JSON1
+        try:
+            cur.execute(
+                f"""SELECT person_did, COUNT(*)
+                    FROM events
+                    WHERE LOWER(COALESCE(json_extract(source,'$.sender'), '')) IN ({placeholders})
+                    GROUP BY 1""",
+                lower_variants,
+            )
+            for did, c in cur.fetchall():
+                if did and c:
+                    evidence[str(did)] += int(c)
+        except Exception:
+            pass
+        try:
+            cur.execute(
+                f"""SELECT e.person_did, COUNT(*)
+                    FROM events AS e, json_each(e.rel, '$.participants') AS p
+                    WHERE LOWER(COALESCE(p.value, '')) IN ({placeholders})
+                    GROUP BY 1""",
+                lower_variants,
+            )
+            for did, c in cur.fetchall():
+                if did and c:
+                    evidence[str(did)] += int(c)
+        except Exception:
+            pass
+
+    # Fallback: light Python scan if SQL didn’t help
+    if not evidence:
+        persons = db_persons()
+        target_norm = {normalize_handle_for_matching(v) for v in variants} | set(norm)
+        for did in persons:
+            for ev in iter_events(did):
+                if ev.kind.name != "MESSAGE":
+                    continue
+                snd = ev.source.get("sender") or ""
+                if normalize_handle_for_matching(snd) in target_norm:
+                    evidence[did] += 1
+                    break
+
+    winners = [did for did, c in evidence.items() if c > 0]
+    if len(winners) == 1:
+        return winners[0], dict(evidence)
+    return None, dict(evidence)


### PR DESCRIPTION
## Summary
- add person_resolver helper for listing persons and guessing person by contact handle
- extend `imx unify` CLI with `--list-persons` and `--auto-person` to auto-select unique matches
- document how to choose a person and add tests for person resolution

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7afa00f988330980eea92d82e4c06